### PR TITLE
added a dumpMergeFrontendServer method

### DIFF
--- a/src/methods/dump.js
+++ b/src/methods/dump.js
@@ -56,7 +56,6 @@ export function dumpMergeFrontendServer () {
   const { backend, frontend } = this
   const serversDir = path.join(backend.dir, 'servers')
   const serverDirs = fs.readdirSync(serversDir)
-  console.log('serverDirs', serverDirs)
   if (serverDirs.includes('_p_frontend-server')) {
     const frontendServerDir = path.join(serversDir, '_p_frontend-server')
     // we actually move and merge the frontend server into the specified frontend server

--- a/src/methods/dump.js
+++ b/src/methods/dump.js
@@ -1,4 +1,5 @@
 import childProcess from 'child_process'
+import fs from 'fs'
 import { flatten, reverse, uniq } from 'lodash'
 import path from 'path'
 
@@ -13,6 +14,7 @@ export function dumpProject () {
   const { project } = this
   // boilerplate
   this.dumpProjectBoilerplate()
+  this.dumpMergeFrontendServer()
   // info
   this.consoleInfo(`Your ${project.package.name} project was successfully dumped!`)
 }
@@ -48,6 +50,22 @@ export function getDumpProjectBoilerplateCommand () {
         .join(' ')
       return `rsync -rv ${excludeOption} ${templateDir}/ ${project.dir}`
     }).join(' && ')
+}
+
+export function dumpMergeFrontendServer () {
+  const { backend, frontend } = this
+  const serversDir = path.join(backend.dir, 'servers')
+  const serverDirs = fs.readdirSync(serversDir)
+  console.log('serverDirs', serverDirs)
+  if (serverDirs.includes('_p_frontend-server')) {
+    const frontendServerDir = path.join(serversDir, '_p_frontend-server')
+    // we actually move and merge the frontend server into the specified frontend server
+    let command = `rsync -rv ${frontendServerDir}/* ${serversDir}/${frontend.serverName}`
+    command += `&& rm -rf ${frontendServerDir}`
+    this.consoleLog(command)
+    const buffer = childProcess.execSync(command)
+    console.log(buffer.toString('utf-8'))
+  }
 }
 
 export function dumpServerBaseRequirements () {

--- a/src/methods/replace.js
+++ b/src/methods/replace.js
@@ -36,14 +36,16 @@ export function replace () {
 export function replaceProject () {
   const { program, project } = this
   // boilerplate
-  program.method = 'replacePlaceholderFiles'
+  program.method = 'replaceServerPlaceholderFiles'
   program.methods = null
   this.mapInTypesAndServers()
+  // boilerplate
+  this.replaceBundlerPlaceholderFiles()
   // info
   this.consoleInfo(`Your ${project.package.name} project was successfully replaced!`)
 }
 
-export function replacePlaceholderFiles () {
+export function replaceServerPlaceholderFiles () {
   // unpack
   const { backend, project, program, type, run, server } = this
   // connect if no port was set here
@@ -76,6 +78,7 @@ export function replacePlaceholderFiles () {
   // for each template replace
   this.getAllTemplateNames().forEach(templateName => {
     const templateDir = path.join(project.nodeModulesDir, templateName)
+    // replace at the server scope
     const templateServerDir = path.join(templateDir, 'backend/servers', server.name)
     const templateFileDirs = glob.sync(path.join(templateServerDir, `**/${templatePrefix}*`))
     templateFileDirs.forEach(templateFileDir => {
@@ -122,5 +125,25 @@ export function replacePlaceholderFiles () {
       const templateFile = fs.readFileSync(templateFileDir, 'utf-8')
       fs.writeFileSync(installedFileDir, formatString(templateFile, this))
     })
+  })
+}
+
+export function replaceBundlerPlaceholderFiles () {
+  const { project } = this
+  this.getAllTemplateNames().forEach(templateName => {
+    const templateDir = path.join(project.nodeModulesDir, templateName)
+    // replace at the server scope
+    const templateBundlerDir = path.join(templateDir, 'bundler')
+    if (fs.existsSync(templateBundlerDir)) {
+      const templateFileDirs = glob.sync(path.join(templateBundlerDir, `**/${templatePrefix}*`))
+      templateFileDirs.forEach(templateFileDir => {
+        const dirChunks = templateFileDir.split('/')
+        let installedFileName = dirChunks.slice(-1)[0]
+                                         .replace(templatePrefix, '')
+        const installedFileDir = path.join(project.dir, 'bundler', installedFileName)
+        const templateFile = fs.readFileSync(templateFileDir, 'utf-8')
+        fs.writeFileSync(installedFileDir, formatString(templateFile, this))
+      })
+    }
   })
 }

--- a/src/methods/set.js
+++ b/src/methods/set.js
@@ -252,8 +252,7 @@ export function setFrontendEnvironment () {
   const serverNames = Object.keys(backend.serversByName)
   frontend.serverName = frontend.serverName ||
     serverNames.find(serverName => /\w+-webrouter/.test(serverName)) ||
-    serverNames.find(serverName => /\w+-websocketer/.test(serverName))
-  console.log('frontend', frontend)
+    serverNames.find(serverName => /\w+-websocket/.test(serverName))
 }
 
 export function getActivatedPythonVenvCommand () {

--- a/src/methods/set.js
+++ b/src/methods/set.js
@@ -36,6 +36,7 @@ export function setProjectEnvironment () {
     // sub entities
     this.setTypeEnvironment()
     this.setBackendEnvironment()
+    this.setFrontendEnvironment()
   }
 }
 
@@ -238,6 +239,21 @@ export function setAllTypesAndServersEnvironment () {
     this.mapInTypesAndServers()
     this.allTypesAndProjets = true
   }
+}
+
+export function setFrontendEnvironment () {
+  const { backend, project } = this
+  if (typeof project.config.frontend === 'undefined') {
+    this.frontend = null
+    return
+  }
+  const frontend = this.frontend = project.config.frontend
+  // we need to resolve the frontend server
+  const serverNames = Object.keys(backend.serversByName)
+  frontend.serverName = frontend.serverName ||
+    serverNames.find(serverName => /\w+-webrouter/.test(serverName)) ||
+    serverNames.find(serverName => /\w+-websocketer/.test(serverName))
+  console.log('frontend', frontend)
 }
 
 export function getActivatedPythonVenvCommand () {


### PR DESCRIPTION
@franblas 

here is a addon of code in teleport helping for merging a backend html rendering web boilerplate to the good server given the specific config of an app.

It results into having a second  this.dumpMergeFrontendServer() after the first one  this.dumpProjectBoilerplate() during the dump time.