### PR TITLE
Transfers platforms into teleport repo

### DIFF
--- a/platforms/README.md
+++ b/platforms/README.md
@@ -1,0 +1,5 @@
+# Platform templates
+A collection of platform templates for Teleport tool.
+
+- [Docker + Kubernetes](docker/)
+- [Heroku](heroku/)

--- a/platforms/docker/.teleport.json
+++ b/platforms/docker/.teleport.json
@@ -1,36 +1,34 @@
 {
 	"backend": {
-		"domain": "corp.snips.ai",
+		"domain": "",
 		"helpersByName": {
 			"docker": {
-				"host": "prod1.corp.snips.ai",
+				"host": "",
 				"imagesByName": {
 					"base": {
-						"tag": "base",
-						"version": "0.8"
+						"tag": "ubuntu",
+						"version": "14.04"
 					},
 					"current": {
 						"maintainer": {
-								"name": "Erwan Ledoux",
-								"email": "erwan.ledoux@snips.ai"
+								"name": "Teleport",
+								"email": "<teleport@teleport.com>"
 						}
 					}
 				},
-				"port": "4243",
+				"tcp": false,
+				"port": "",
 				"registry": {
-					"host": "registry.corp.snips.ai",
-					"port": "5000"
+					"host": "",
+					"port": ""
 				},
 				"version": "1.10.2"
 			},
 			"kubernetes": {
-				"host": "infra2.corp.snips.ai",
-				"port": "8080",
-				"nodeDomain": "corp.snips.ai",
-				"url": "http://infra2.corp.snips.ai:8080/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/"
-			},
-			"smtp": {
-				"host": "smtp.corp.snips.net"
+				"host": "",
+				"port": "",
+				"nodeDomain": "",
+				"url": ""
 			}
 		}
 	},
@@ -38,17 +36,17 @@
 		"localhost": {
 		},
 		"production": {
-			"subDomain": "prod2",
+			"subDomain": "",
 			"hasDns": true,
 			"abbreviation": "prod"
 		},
 		"staging": {
-			"subDomain": "dev3",
+			"subDomain": "",
 			"hasDns": true,
 			"abbreviation": "stg"
 		},
 		"unname": {
-			"subDomain": "dev3",
+			"subDomain": "",
 			"abbreviation": "unm"
 		}
 	}

--- a/platforms/docker/.teleport.json
+++ b/platforms/docker/.teleport.json
@@ -19,8 +19,7 @@
 				"tcp": false,
 				"port": "",
 				"registry": {
-					"host": "",
-					"port": ""
+					"url": "index.docker.io"
 				},
 				"version": "1.10.2"
 			},

--- a/platforms/docker/.teleport.json
+++ b/platforms/docker/.teleport.json
@@ -1,0 +1,55 @@
+{
+	"backend": {
+		"domain": "corp.snips.ai",
+		"helpersByName": {
+			"docker": {
+				"host": "prod1.corp.snips.ai",
+				"imagesByName": {
+					"base": {
+						"tag": "base",
+						"version": "0.8"
+					},
+					"current": {
+						"maintainer": {
+								"name": "Erwan Ledoux",
+								"email": "erwan.ledoux@snips.ai"
+						}
+					}
+				},
+				"port": "4243",
+				"registry": {
+					"host": "registry.corp.snips.ai",
+					"port": "5000"
+				},
+				"version": "1.10.2"
+			},
+			"kubernetes": {
+				"host": "infra2.corp.snips.ai",
+				"port": "8080",
+				"nodeDomain": "corp.snips.ai",
+				"url": "http://infra2.corp.snips.ai:8080/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/"
+			},
+			"smtp": {
+				"host": "smtp.corp.snips.net"
+			}
+		}
+	},
+	"typesByName": {
+		"localhost": {
+		},
+		"production": {
+			"subDomain": "prod2",
+			"hasDns": true,
+			"abbreviation": "prod"
+		},
+		"staging": {
+			"subDomain": "dev3",
+			"hasDns": true,
+			"abbreviation": "stg"
+		},
+		"unname": {
+			"subDomain": "dev3",
+			"abbreviation": "unm"
+		}
+	}
+}

--- a/platforms/docker/.teleport.json
+++ b/platforms/docker/.teleport.json
@@ -44,10 +44,6 @@
 			"subDomain": "",
 			"hasDns": true,
 			"abbreviation": "stg"
-		},
-		"unname": {
-			"subDomain": "",
-			"abbreviation": "unm"
 		}
 	}
 }

--- a/platforms/docker/.teleport.json
+++ b/platforms/docker/.teleport.json
@@ -6,8 +6,8 @@
 				"host": "",
 				"imagesByName": {
 					"base": {
-						"tag": "ubuntu",
-						"version": "14.04"
+						"tag": "franblas/teleportjs",
+						"version": "0.1"
 					},
 					"current": {
 						"maintainer": {

--- a/platforms/docker/README.md
+++ b/platforms/docker/README.md
@@ -1,0 +1,11 @@
+# teleport-snips
+This is a template from the app https://github.com/snipsco/teleport. It helps you to build a server that is deployed with our particular snips docker/kubernetes config.
+
+You can test yourself with
+
+```
+tpt -c --project my-app --templates teleport-flask-webrouter,teleport-snips
+```
+and then follow these instructions https://github.com/snipsco/teleport/blob/master/README.md#start-a-new-project
+
+See for instance how this was used to deploy our slack bot https://github.com/snipsco/snips-sdk-ds/tree/master/tools/slack-sdk

--- a/platforms/docker/README.md
+++ b/platforms/docker/README.md
@@ -23,7 +23,7 @@ Deployment configuration for [teleport](https://github.com/snipsco/teleport) in 
 ### typesByName
 - <key>
   - subDomain: prefix added to nodeDomain. Default to None. [REQUIRED]
-  - hasDns: TODO
+  - hasDns: TODO [REQUIRED]
   - abbreviation: special tag for containers. [REQUIRED]
 
 ## How to use it

--- a/platforms/docker/README.md
+++ b/platforms/docker/README.md
@@ -11,8 +11,7 @@ Deployment configuration for [teleport](https://github.com/snipsco/teleport) in 
     - tcp: docker socket. If set to true, port and host should be defined. By default unix socket.
     - port: docker socket port. By default None.
     - registry
-      - host: docker registry hostname. If point to a private registry, you should provide a port. By default public one.
-      - port: docker registry port. By default None.
+      - url: docker registry url. By default public one.
     - version: docker server version. By default 1.10.2.
   - kubernetes
     - host: kubernetes master hostname. By default None. [REQUIRED]

--- a/platforms/docker/README.md
+++ b/platforms/docker/README.md
@@ -1,11 +1,33 @@
-# teleport-snips
-This is a template from the app https://github.com/snipsco/teleport. It helps you to build a server that is deployed with our particular snips docker/kubernetes config.
+# teleport-docker
+Deployment configuration for [teleport](https://github.com/snipsco/teleport) in the case of a docker/kubernetes infrastructure.
 
-You can test yourself with
+## Ontology
+### backend
+- domain: main subdomain of the app dns
+- helpersByName
+  - docker
+    - host: docker server hostname. By default localhost.
+    - imagesByName: base docker image configuration. By default the teleport one.
+    - tcp: docker socket. If set to true, port and host should be defined. By default unix socket.
+    - port: docker socket port. By default None.
+    - registry
+      - host: docker registry hostname. If point to a private registry, you should provide a port. By default public one.
+      - port: docker registry port. By default None.
+    - version: docker server version. By default 1.10.2.
+  - kubernetes
+    - host: kubernetes master hostname. By default None. [REQUIRED]
+    - port: kubernetes master port. By default None. [REQUIRED]
+    - nodeDomain: kubernetes node subdomain. By default None.
+    - url: kubernetes dashboard url. By default None.
 
+### typesByName
+- <key>
+  - subDomain: prefix added to nodeDomain. Default to None. [REQUIRED]
+  - hasDns: TODO
+  - abbreviation: special tag for containers. [REQUIRED]
+
+## How to use it
+Simply add it to the list of templates. For instance:
 ```
-tpt -c --project my-app --templates teleport-flask-webrouter,teleport-snips
+tpt -c --project my-app --templates teleport-flask-webrouter,teleport-docker
 ```
-and then follow these instructions https://github.com/snipsco/teleport/blob/master/README.md#start-a-new-project
-
-See for instance how this was used to deploy our slack bot https://github.com/snipsco/snips-sdk-ds/tree/master/tools/slack-sdk

--- a/platforms/docker/package.json
+++ b/platforms/docker/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "teleport-docker",
+  "version": "0.1.0"
+}

--- a/platforms/heroku/.teleport.json
+++ b/platforms/heroku/.teleport.json
@@ -1,0 +1,21 @@
+{
+	"backend": {
+		"domain": "herokuapp.com",
+		"helpersByName": {
+			"heroku": {
+			}
+		}
+	},
+	"typesByName": {
+		"localhost": {
+		},
+		"production": {
+			"abbreviation": "prod",
+			"hasDns": true
+		},
+		"staging": {
+			"abbreviation": "stg",
+			"hasDns": true
+		}
+	}
+}

--- a/platforms/heroku/README.md
+++ b/platforms/heroku/README.md
@@ -1,2 +1,19 @@
 # teleport-heroku
-teleport template for heroku
+Deployment configuration for [teleport](https://github.com/snipsco/teleport) in the case of heroku infrastructure.
+
+## Ontology
+### backend
+- domain: main subdomain of the app dns. By default herokuapp.com.
+- helpersByName
+  - heroku
+
+### typesByName
+- <key>
+  - hasDns: TODO [REQUIRED]
+  - abbreviation: special tag for apps. [REQUIRED]
+
+## How to use it
+Simply add it to the list of templates. For instance:
+```
+tpt -c --project my-app --templates teleport-flask-webrouter,teleport-heroku
+```

--- a/platforms/heroku/README.md
+++ b/platforms/heroku/README.md
@@ -1,0 +1,2 @@
+# teleport-heroku
+teleport template for heroku

--- a/platforms/heroku/package.json
+++ b/platforms/heroku/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "teleport-heroku",
+  "version": "0.1.0"
+}


### PR DESCRIPTION
Teleport platforms templates should be in teleport repository. Overkill to setup a github repo for this. Moreover we have a better overview and it's still npm packages.
WDYT? @Ledoux 
