### PR TITLE
Linux compatibility

### DIFF
--- a/bin/link.sh
+++ b/bin/link.sh
@@ -1,3 +1,3 @@
 APP_DIR=$PWD
 APP_CMD=tpt
-cd /usr/local/bin && ln -sf $APP_DIR/bin/index.js $APP_CMD && chmod +ux $APP_CMD && chmod +ux $APP_DIR/bin/index.py && cd $APP_DIR
+cd /usr/local/bin && ln -sf $APP_DIR/bin/index.js $APP_CMD && chmod +x $APP_CMD && chmod +x $APP_DIR/bin/index.py && cd $APP_DIR

--- a/bin/link.sh
+++ b/bin/link.sh
@@ -1,3 +1,3 @@
-APP_DIR=$PWD
+APP_DIR=$(pwd)
 APP_CMD=tpt
 cd /usr/local/bin && ln -sf $APP_DIR/bin/index.js $APP_CMD && chmod +x $APP_CMD && chmod +x $APP_DIR/bin/index.py && cd $APP_DIR

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "json-stable-stringify": "^1.0.1",
     "mkdirp": "^0.5.1",
     "nodemon": "^1.11.0",
-    "pluralize": "^3.0.0",
-    "ttab": "^0.5.0"
+    "pluralize": "^3.0.0"
   },
   "main": "lib/index.js",
   "name": "teleport.js",
@@ -21,10 +20,10 @@
     "registry": "https://npm-registry.corp.snips.net"
   },
   "scripts": {
-    "compile": "rm -rf lib && mkdir -p lib && ./node_modules/.bin/babel --presets es2015,stage-3 -d lib/ src/",
-    "postinstall": "source bin/link.sh && npm run compile",
+    "compile": "./node_modules/.bin/babel --presets es2015,stage-3 -d lib/ src/",
+    "postinstall": "rm -rf lib && mkdir -p lib && source bin/link.sh && npm run compile",
     "update": "npm unpublish teleport.js@0.0.1 && npm publish",
     "watch": "./node_modules/nodemon/bin/nodemon.js src/index.js --watch src --exec babel-node --presets es2015,stage-3"
   },
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/package.json
+++ b/package.json
@@ -21,9 +21,12 @@
   },
   "scripts": {
     "compile": "./node_modules/.bin/babel --presets es2015,stage-3 -d lib/ src/",
-    "postinstall": "rm -rf lib && mkdir -p lib && source bin/link.sh && npm run compile",
+    "postinstall": "rm -rf lib && mkdir -p lib && npm run compile",
     "update": "npm unpublish teleport.js@0.0.1 && npm publish",
     "watch": "./node_modules/nodemon/bin/nodemon.js src/index.js --watch src --exec babel-node --presets es2015,stage-3"
+  },
+  "bin": {
+    "tpt": "bin/index.js"
   },
   "version": "0.1.1"
 }


### PR DESCRIPTION
- Remove `ttab` dep. Not removed from command line source code
- Fix the postinstall script. No need to link!

Working like a charm on Linux 🐧🐧🐧

@Ledoux 