### PR TITLE
made teleport invent a uniq id name for project

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 // regeneratorRuntime is needed for async await
 import 'babel-polyfill'
 
+import { id } from './utils'
+
 const methods = [
   'build',
   'configure',
@@ -58,6 +60,11 @@ class Teleport {
     }
     // if we want to create something, then we return because we are not in a scope or in a project yet
     if (typeof program.create !== 'undefined') {
+      // in the case where no project name was given, we need to invent one based on a uniq ID
+      if (typeof program.project !== 'string') {
+        this.consoleWarn('You didn\'t mention any particular name, we are going to give you one')
+        program.project = `app-${id()}`
+      }
       this.level = ['project'].find(level => program[level])
       return
     }

--- a/src/methods/create.js
+++ b/src/methods/create.js
@@ -10,11 +10,6 @@ export function create () {
 export function createProject () {
   // unpack
   const { app, project, program } = this
-  // warn
-  if (typeof program.project !== 'string') {
-    this.consoleWarn('You didn\'t mention any particular name, please configure --project <your_project_name> in your command')
-    return
-  }
   // check if such a project exists already here
   project.dir = path.join(this.currentDir, program.project)
   this.consoleInfo(`wait a second... We create your ${program.project} project !`)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -137,3 +137,12 @@ export function getCartesianProduct (...args) {
     }), true)
   }, [ [] ])
 }
+
+export function id () {
+  function s4 () {
+    return Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16)
+      .substring(1);
+  }
+  return s4() + s4()
+}


### PR DESCRIPTION
@franblas 
to avoid the case where the coders will try the cli for the first time with a stupid name, it is better to show an example where the id of their app is actually uniq (to not make them publish on the same heroku url).

So here Teleport now proposes a project name with specific id if the user does not specify it.