### PR TITLE
teleport 2.2 with new prefix systems

### DIFF
--- a/bin/postinstall.sh
+++ b/bin/postinstall.sh
@@ -1,7 +1,3 @@
-if [ ! -f ".projects.json" ] ; then
-  echo "{}" > .projects.json
-  chmod -R +w ../teleport
-fi
 rm -rf lib
 mkdir -p lib
 npm run compile

--- a/docs/backend_templates.md
+++ b/docs/backend_templates.md
@@ -11,7 +11,7 @@ Here are some additional informations about backend templates architecture. As a
 |   +-- .dockerignore
 |   +-- express-webrouter
 |   |   +-- Procfile
-|   |   +-- _p_Dockerfile
+|   |   +-- <REPLACE_FOR_EACH_TYPE>_Dockerfile
 |   |   +-- package.json
 |   |   +-- app
 |   |   |   +-- index.js
@@ -19,15 +19,15 @@ Here are some additional informations about backend templates architecture. As a
 |   |   |   +-- static
 |   |   |   +-- ...
 |   |   +-- scripts
-|   |   |   +-- _p_heroku_run.sh
-|   |   |   +-- _p_run.sh
-|   |   |   +-- _p_heroku_build.sh
-|   |   |   +-- _p_build.sh
+|   |   |   +-- <REPLACE_FOR_EACH_TYPE>_heroku_run.sh
+|   |   |   +-- <REPLACE_FOR_EACH_TYPE>_run.sh
+|   |   |   +-- <REPLACE_FOR_EACH_TYPE>_heroku_build.sh
+|   |   |   +-- <REPLACE_FOR_EACH_TYPE>_build.sh
 |   |   |   +-- ...
 |   |   +-- config
-|   |   |   +-- _p_controller.yaml
-|   |   |   +-- _p_service.yaml
-|   |   |   +-- _p_uwsgi.ini
+|   |   |   +-- <REPLACE_FOR_EACH_TYPE>_controller.yaml
+|   |   |   +-- <REPLACE_FOR_EACH_TYPE>_service.yaml
+|   |   |   +-- <REPLACE_FOR_EACH_TYPE>_uwsgi.ini
 |   |   |   +-- heroku_uwsgi.ini
 ```
 
@@ -41,7 +41,7 @@ NB: the name of the folder should match the `serversByName` first key into the `
 
 ### Into express-webrouter
 - *Procfile*: define commands that will run on the deployed app. It's specific to Heroku platform (see https://devcenter.heroku.com/articles/procfile).
-- *_p_Dockerfile*: define the application image. It's specific to Docker.
+- *<REPLACE_FOR_EACH_TYPE>_Dockerfile*: define the application image. It's specific to Docker.
 - *package.json*: define requirements for the deployed application. It's necessary for the Heroku app to have it at this level, moreover it's specific to our case (nodejs express), for a python app it should be a `requirements.txt` (see https://devcenter.heroku.com/articles/python-pip).
 
 #### app

--- a/docs/frontend_templates.md
+++ b/docs/frontend_templates.md
@@ -14,8 +14,8 @@ Here are some additional informations about frontend templates architecture. As 
 |   +-- bundle.sh
 |   +-- localhost_bundle.sh
 +-- bundler
-|   +-- _p_config.js
-|   +-- _p_hotAssetsServer.js
+|   +-- <REPLACE>config.js
+|   +-- <REPLACE>hotAssetsServer.js
 |   +-- dev.config.js
 |   +-- prod.config.js
 +-- frontend
@@ -51,4 +51,4 @@ In this folder we should have the frontend application. The architecture should 
 
 Nb: The app should be loaded into a single div container with the ID `app_div`. Remember that this is the ID we gave into our backend templates for the `index.html`.
 
-If the frontend failed to load (bundle not working or app not loaded properly...) then we fallback on the backend api and server the index template of the backend. 
+If the frontend failed to load (bundle not working or app not loaded properly...) then we fallback on the backend api and server the index template of the backend.

--- a/src/methods/dump.js
+++ b/src/methods/dump.js
@@ -7,7 +7,8 @@
 // One important point is that dump does not rsync important dirs listed in
 // the 'excludedDirs' array global variable. Indeed some of them (essentially
 // the config files like package.json) has been already merged during the
-// configure time (a previous init sub task). Others that are prefixed by _p_
+// configure time (a previous init sub task). Others that are prefixed by
+// <REPLACE>, <REPLACE_FOR_EACH_TYPE>_
 // are placeholder files that will be actually added at the replace
 // time (which is a sub task of install).
 // - if you have a frontend bundling template, teleport has at this stage
@@ -25,6 +26,7 @@ import fs from 'fs'
 import { flatten, reverse, uniq } from 'lodash'
 import path from 'path'
 
+import { templatePrefixes } from '../utils/constants'
 import { getRequirements, writeRequirements } from '../utils/functions'
 
 export function dump () {
@@ -48,8 +50,10 @@ export function getDumpProjectBoilerplateCommand () {
     '.gitignore',
     'README.md',
     configFile,
-    '\'_p_*\''
-  ]
+  // ignore also all the placeholder files because they are going
+  //to be created at the replace time
+  ].concat(templatePrefixes
+    .map(templatePrefix => `\'${templatePrefix}*\'`))
   return project.config.templateNames
     .map(templateName => {
       const templateDir = path.join(project.nodeModulesDir, templateName)

--- a/src/methods/exec.js
+++ b/src/methods/exec.js
@@ -40,7 +40,7 @@ export function exec () {
       // NOTE : this is where we need to do a little hacky workaround.
       // our default platform value is heroku, but our scripts in our templates
       // are by default kubernetes if they don't have a prefix platform
-      platform !== 'teleport-snips'
+      (platform !== 'kubernetes' || platform !== 'teleport-snips')
     ) {
       typedScript = `${platform}_${script}`
     }

--- a/src/methods/exec.js
+++ b/src/methods/exec.js
@@ -20,19 +20,27 @@ const platformScriptNames = [
 ]
 
 export function exec () {
-  const { app, program, server, type } = this
+  const { app, program, project, server, type } = this
   let command, scriptFile
   // execute a script
   const script = program.script
   if (typeof script !== 'undefined' && server) {
     let platform = program.platform
     let typedScript = script
+    // look how many platforms we have
+    if (typeof project.platformTemplateNames === 'undefined') {
+      project.platformTemplateNames = this.getPlatformTemplates()
+    }
+    if (project.platformTemplateNames.length === 1 && platform !== 'heroku') {
+      platform = project.platformTemplateNames[0]
+    }
+    // check
     if (
       platformScriptNames.includes(script) && platform &&
       // NOTE : this is where we need to do a little hacky workaround.
       // our default platform value is heroku, but our scripts in our templates
       // are by default kubernetes if they don't have a prefix platform
-      platform !== 'kubernetes'
+      platform !== 'teleport-snips'
     ) {
       typedScript = `${platform}_${script}`
     }

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -84,11 +84,11 @@ export function getTemplateNames () {
 
 export function getDepTemplateNames (templateName, depTemplateNames = []) {
   const { project } = this
-  depTemplateNames.push(templateName)
   const templateDir = path.join(project.dir, 'node_modules', templateName)
   let templateConfig = this.getConfig(templateDir)
   const templatePackage = getPackage(templateDir)
-  if (typeof templatePackage !== 'undefined' && typeof templateConfig !== 'undefined') {
+  if (templatePackage && templateConfig) {
+    depTemplateNames.push(templateName)
     const dependencies = Object.assign({}, templatePackage.dependencies, templatePackage.devDependencies)
     Object.keys(dependencies)
       .forEach(depTemplateName =>

--- a/src/methods/get.js
+++ b/src/methods/get.js
@@ -105,6 +105,14 @@ export function getAllTemplateNames () {
   ))
 }
 
+export function getPlatformTemplates () {
+  const { project: { config, dir } } = this
+  return config.templateNames.filter(templateName => {
+    const templateDir = path.join(project.nodeModulesDir, templateName)
+    return this.getConfig(templateDir).isPlatform
+  })
+}
+
 export function getTemplateDependencies () {
   const { project: { config, dir } } = this
   return _.fromPairs(config.templateNames

--- a/src/methods/replace.js
+++ b/src/methods/replace.js
@@ -60,6 +60,10 @@ export function replace () {
 export function replaceServerPlaceholderFiles () {
   // unpack
   const { backend, project, program, type, run, server, welcome } = this
+  // check
+  if (typeof welcome === 'undefined') {
+    this.setWelcomeEnvironment()
+  }
   // connect if no port was set here
   if (type.name !== 'localhost' && typeof run.port === 'undefined') {
     this.connect()
@@ -157,7 +161,13 @@ export function replaceServerPlaceholderFiles () {
 }
 
 export function replaceBundlerPlaceholderFiles () {
+  // unpack
   const { project, welcome } = this
+  // check
+  if (typeof welcome === 'undefined') {
+    this.setWelcomeEnvironment()
+  }
+  // replace
   welcome.allTemplateNames.forEach(templateName => {
     const templateDir = path.join(project.nodeModulesDir, templateName)
     // replace at the server scope

--- a/src/methods/replace.js
+++ b/src/methods/replace.js
@@ -3,37 +3,33 @@
 // created project if you want to recopy the placeholder files.
 // - replace goes to each server of the project and looks at all the placholder files
 // for each template.
-// Placeholder files are matched via the _p_ prefix in their file name.
+// Placeholder files are matched via the <REPLACE>, <REPLACE_FOR_EACH_TYPE>_ prefixes in their file name.
 // In these files all the $[] instances are replaced with values from this teleport object.
 // You can check more precisely how the formatString function works in the ../utils/functions.js.
-// Note also that the replace method will for each _p_<file_name> placeholder file
+// Note also that the replace method will for each <REPLACE_FOR_EACH_TYPE>_<file_name> placeholder file
 // create one file per type (localhost, staging and production in the common case).
 // Meaning that you will have localhost_<file_name>, staging_<file_name>,
 // production_<file_name> created.
-// - replace goes to your bundler folder and does the same thing, except
-// that it is not going to create one file per type, just only one.
+// - replace goes to your bundler folder and does the same thing
 
 import fs from 'fs'
 import glob from 'glob'
+import { flatten } from 'lodash'
 import mkdirp from 'mkdirp'
 import path from 'path'
 
+import { templatePrefixes } from '../utils/constants'
 import { formatString, getPackage } from '../utils/functions'
 
 const dockerPlaceholderfiles = [
   'build.sh',
   'controller.yaml',
-  'Dockerfile',
-  'service.yaml'
-]
-
-const deployPlaceholderfiles = [
-  'build.sh',
-  'controller.yaml',
   'deploy.sh',
+  'Dockerfile',
   'push.sh',
   'run.sh',
-  'service.yaml'
+  'service.yaml',
+  'start.sh'
 ]
 
 const notLocalhostPlaceholderFiles = [
@@ -48,7 +44,6 @@ const notLocalhostPlaceholderFiles = [
   /.*run.sh$/,
   /.*service.yaml$/
 ]
-const templatePrefix = '_p_'
 
 export function replace () {
   const { program, project } = this
@@ -64,41 +59,17 @@ export function replace () {
 
 export function replaceServerPlaceholderFiles () {
   // unpack
-  const { backend, project, program, type, run, server } = this
+  const { backend, project, program, type, run, server, welcome } = this
   // connect if no port was set here
   if (type.name !== 'localhost' && typeof run.port === 'undefined') {
     this.connect()
   }
   // add types
   project.typeNames = Object.keys(project.config.typesByName)
-  // add templateUrls in the context
-  const allTemplateNames = this.getAllTemplateNames()
-  const templates = allTemplateNames
-    .map(templateName => {
-      const templateDir = path.join(project.nodeModulesDir, templateName)
-      let templateConfig = this.getConfig(templateDir)
-      if (typeof templateConfig === 'undefined') {
-        this.consoleWarn(`this template ${templateName} has no config`)
-        templateConfig = {}
-      }
-      const templatePackage = getPackage(templateDir)
-      let templateRepository = templatePackage.repository
-      if (typeof templateRepository === 'undefined') {
-        if (typeof config === 'undefined') {
-          this.consoleWarn(`this template ${templateName} has no repository in package`)
-        }
-        templateRepository = {}
-      }
-      return {
-        iconUrl: templateConfig.iconUrl,
-        gitUrl: templateRepository.url,
-        name: templateName
-      }})
   // prepare the extraConfig
   const extraConfig = Object.assign(
     {
       'SITE_NAME': backend.siteName,
-      'TEMPLATES': `'${JSON.stringify(templates)}'`,
       'TYPE': type.name
     },
     backend.dockerEnv,
@@ -119,21 +90,36 @@ export function replaceServerPlaceholderFiles () {
     this.manageExtraConfig = `${this.manageExtraConfig} &&`
   }
   // for each template replace
-  allTemplateNames.forEach(templateName => {
+  welcome.allTemplateNames.forEach(templateName => {
     const templateDir = path.join(project.nodeModulesDir, templateName)
     // replace at the server scope
     const templateServerDir = path.join(templateDir, 'backend/servers', server.name)
-    const templateFileDirs = glob.sync(path.join(templateServerDir, `**/${templatePrefix}*`))
-    templateFileDirs.forEach(templateFileDir => {
+    // let's get for all the possible placeholders prefix the matching files
+    // and attach to them the prefix
+    const templateCouples = flatten(templatePrefixes.map(templatePrefix =>
+      glob.sync(path.join(templateServerDir, `**/${templatePrefix}*`))
+        .map(templateFileDir => [templatePrefix, templateFileDir])
+    ))
+    // for each we can decide how to set the installedFileName
+    templateCouples.forEach(templateCouple => {
+      // unpack
+      const [templatePrefix, templateFileDir] = templateCouple
       const dirChunks = templateFileDir.split('/')
+      const templatePathDir = dirChunks.slice(0, -1).join('/')
       let installedFileName = dirChunks.slice(-1)[0]
-                                       .replace(templatePrefix, '')
-      // we know that there are some script and config files dedicated to the deploy step
-      // so we don't have actually to write them for the localhost type case
+                                .replace(templatePrefix, '')
       if (type.name === 'localhost') {
+        // we know that there are some script and config files dedicated to the deploy step
+        // so we don't have actually to write them for the localhost type case
         if (notLocalhostPlaceholderFiles.some(notLocalhostPlaceholderFile => {
           return notLocalhostPlaceholderFile.test(installedFileName)
         })) {
+          return
+        }
+        // no need also to replace and write when actually there is already the
+        // locahost placeholder file
+        const localhostTemplateDir = `${templatePathDir}/__localhost_${installedFileName}`
+        if (fs.existsSync(localhostTemplateDir)) {
           return
         }
       } else if (installedFileName.split('_')[0] === 'localhost') {
@@ -141,21 +127,13 @@ export function replaceServerPlaceholderFiles () {
         // so if we are not to the localhost case we have to leave
         return
       }
-      // if we are not in the case of a docker deploy file
+      // if we are not in the case of a deploy file
       // we can escape
       if (type.name !== 'localhost' && typeof backend.helpersByName.docker === 'undefined' &&
         dockerPlaceholderfiles.includes(installedFileName)) {
         return
       }
-      const installedParams = installedFileName.split('_')
-      if (
-        installedParams.length === 2 && installedParams[0] !== type.name ||
-        // NOTE HERE A QUICK WORKAROUND SOLUTION
-        // we hardcode the special case of Procfile where we need to make it pass
-        // through the replace, but actually not making it specified
-        // with the type prefix
-        installedParams.length === 1 && installedFileName !== 'Procfile'
-      ) {
+      if (templatePrefix === '<REPLACE_FOR_EACH_TYPE>_') {
         installedFileName = `${type.name}_${installedFileName}`
       }
       const installedFolderDir = path.join(project.dir, 'backend', dirChunks.slice(0, -1)
@@ -179,17 +157,26 @@ export function replaceServerPlaceholderFiles () {
 }
 
 export function replaceBundlerPlaceholderFiles () {
-  const { project } = this
-  this.getAllTemplateNames().forEach(templateName => {
+  const { project, welcome } = this
+  welcome.allTemplateNames.forEach(templateName => {
     const templateDir = path.join(project.nodeModulesDir, templateName)
     // replace at the server scope
     const templateBundlerDir = path.join(templateDir, 'bundler')
     if (fs.existsSync(templateBundlerDir)) {
-      const templateFileDirs = glob.sync(path.join(templateBundlerDir, `**/${templatePrefix}*`))
-      templateFileDirs.forEach(templateFileDir => {
+      const templateCouples = flatten(
+        templatePrefixes.map(templatePrefix =>
+          glob.sync(path.join(templateBundlerDir, `**/${templatePrefix}*`))
+              .map(templateFileDir => [templatePrefix, templateFileDir])
+        ))
+      templateCouples.forEach(templateCouple => {
+        // unpack
+        const [templatePrefix, templateFileDir] = templateCouple
         const dirChunks = templateFileDir.split('/')
         let installedFileName = dirChunks.slice(-1)[0]
                                          .replace(templatePrefix, '')
+        if (templatePrefix === '<REPLACE_FOR_EACH_TYPE>_') {
+          installedFileName = `${type.name}_${installedFileName}`
+        }
         const installedFolderDir = path.join(project.dir, 'bundler')
         const installedFileDir = path.join(installedFolderDir, installedFileName)
         const templateFile = fs.readFileSync(templateFileDir, 'utf-8')

--- a/src/methods/replace.js
+++ b/src/methods/replace.js
@@ -59,10 +59,12 @@ export function replace () {
 
 export function replaceServerPlaceholderFiles () {
   // unpack
-  const { backend, project, program, type, run, server, welcome } = this
+  let { welcome } = this
+  const { backend, project, program, type, run, server } = this
   // check
   if (typeof welcome === 'undefined') {
     this.setWelcomeEnvironment()
+    welcome = this.welcome
   }
   // connect if no port was set here
   if (type.name !== 'localhost' && typeof run.port === 'undefined') {
@@ -162,10 +164,12 @@ export function replaceServerPlaceholderFiles () {
 
 export function replaceBundlerPlaceholderFiles () {
   // unpack
-  const { project, welcome } = this
+  let { welcome } = this
+  const { project } = this
   // check
   if (typeof welcome === 'undefined') {
     this.setWelcomeEnvironment()
+    welcome = this.welcome
   }
   // replace
   welcome.allTemplateNames.forEach(templateName => {

--- a/src/methods/set.js
+++ b/src/methods/set.js
@@ -159,49 +159,52 @@ export function setWelcomeEnvironment () {
   // of each server in order to make them a bit aware to where they come from:
   // what are the templates that made the project and the other servers deployed by the
   // project
-  if (program.create || program.install || program.replace ||
-    program.method === 'replaceServerPlaceholderFiles' || program.method ===
-  'replaceBundlerPlaceholderFiles') {
-    // For having already full information on all the servers
-    // we need to make a loop on each of them to complete their config info
-    this.setAllTypesAndServersEnvironment()
-    // get info on the templates
-    welcome.allTemplateNames = this.getAllTemplateNames()
-    welcome.templatesJSON = JSON.stringify(welcome.allTemplateNames
-      .map(templateName => {
-        const templateDir = path.join(project.nodeModulesDir, templateName)
-        let templateConfig = this.getConfig(templateDir)
-        if (typeof templateConfig === 'undefined') {
-          this.consoleWarn(`this template ${templateName} has no config`)
-          templateConfig = {}
-        }
-        let templatePackage = getPackage(templateDir)
-        if (typeof templatePackage === 'undefined') {
-          this.consoleWarn(`this template ${templateName} has no package`)
-          templatePackage = {}
-        }
-        let templateRepository = templatePackage.repository
-        if (typeof templateRepository === 'undefined') {
-          this.consoleWarn(`this template ${templateName} has no repository in package`)
-          templateRepository = {}
-        }
-        return {
-          iconUrl: templateConfig.iconUrl,
-          gitUrl: templateRepository.url,
-          name: templateName
-        }}), null, 2)
-    }
-    // get also info on the servers
-    welcome.serversJSON = JSON.stringify(Object.keys(this.serversByName || {})
-      .map(serverName => {
-        const server = this.serversByName[serverName]
-        return {
-          name: serverName,
-          types: Object.keys(server.runsByTypeName)
-                .map(type => server.runsByTypeName[type])
-                .map(({url}) => { return { url } })
-        }
-      }), null, 2)
+
+  // For having already full information on all the servers
+  // we need to make a loop on each of them to complete their config info
+  const oldMethod = program.method
+  const oldMethods = program.methods
+  program.method = 'pass'
+  program.methods = null
+  this.setAllTypesAndServersEnvironment()
+  program.method = oldMethod
+  program.methods = oldMethods
+  // get info on the templates
+  welcome.allTemplateNames = this.getAllTemplateNames()
+  welcome.templatesJSON = JSON.stringify(welcome.allTemplateNames
+    .map(templateName => {
+      const templateDir = path.join(project.nodeModulesDir, templateName)
+      let templateConfig = this.getConfig(templateDir)
+      if (typeof templateConfig === 'undefined') {
+        this.consoleWarn(`this template ${templateName} has no config`)
+        templateConfig = {}
+      }
+      let templatePackage = getPackage(templateDir)
+      if (typeof templatePackage === 'undefined') {
+        this.consoleWarn(`this template ${templateName} has no package`)
+        templatePackage = {}
+      }
+      let templateRepository = templatePackage.repository
+      if (typeof templateRepository === 'undefined') {
+        this.consoleWarn(`this template ${templateName} has no repository in package`)
+        templateRepository = {}
+      }
+      return {
+        iconUrl: templateConfig.iconUrl,
+        gitUrl: templateRepository.url,
+        name: templateName
+      }}), null, 2)
+  // get also info on the servers
+  welcome.serversJSON = JSON.stringify(Object.keys(this.serversByName || {})
+    .map(serverName => {
+      const server = this.serversByName[serverName]
+      return {
+        name: serverName,
+        types: Object.keys(server.runsByTypeName)
+              .map(type => server.runsByTypeName[type])
+              .map(({url}) => { return { url } })
+      }
+    }), null, 2)
 }
 
 export function setServerEnvironment () {
@@ -299,9 +302,10 @@ export function setRunEnvironment () {
 }
 
 export function setAllTypesAndServersEnvironment () {
+  const { program } = this
   if (this.allTypesAndProjets !== true) {
-    if (typeof this.program.method === 'undefined') {
-      this.program.method = 'pass'
+    if (typeof program.method === 'undefined') {
+      program.method = 'pass'
     }
     this.mapInTypesAndServers()
     this.allTypesAndProjets = true

--- a/src/methods/set.js
+++ b/src/methods/set.js
@@ -159,16 +159,9 @@ export function setWelcomeEnvironment () {
   // of each server in order to make them a bit aware to where they come from:
   // what are the templates that made the project and the other servers deployed by the
   // project
-
-  // For having already full information on all the servers
+  // For having already full information on all the servers and all types
   // we need to make a loop on each of them to complete their config info
-  const oldMethod = program.method
-  const oldMethods = program.methods
-  program.method = 'pass'
-  program.methods = null
   this.setAllTypesAndServersEnvironment()
-  program.method = oldMethod
-  program.methods = oldMethods
   // get info on the templates
   welcome.allTemplateNames = this.getAllTemplateNames()
   welcome.templatesJSON = JSON.stringify(welcome.allTemplateNames
@@ -304,10 +297,20 @@ export function setRunEnvironment () {
 export function setAllTypesAndServersEnvironment () {
   const { program } = this
   if (this.allTypesAndProjets !== true) {
-    if (typeof program.method === 'undefined') {
-      program.method = 'pass'
-    }
+    // NOTE HERE !! Maybe we are already in a map thread that
+    // uses the program.method or program.methods already.
+    // so for this possible nested map in types and servers
+    // we want to just to set the environments (and not calling method)
+    // so we keep in buffer the method and methods just during the
+    // mapInTypesAndServers
+    const oldMethod = program.method
+    const oldMethods = program.methods
+    program.method = 'pass'
+    program.methods = null
     this.mapInTypesAndServers()
+    // and we set it again here to make continue the process
+    program.method = oldMethod
+    program.methods = oldMethods
     this.allTypesAndProjets = true
   }
 }

--- a/src/methods/set.js
+++ b/src/methods/set.js
@@ -193,7 +193,7 @@ export function setWelcomeEnvironment () {
         }}), null, 2)
     }
     // get also info on the servers
-    welcome.serversJSON = JSON.stringify(Object.keys(this.serversByName)
+    welcome.serversJSON = JSON.stringify(Object.keys(this.serversByName || {})
       .map(serverName => {
         const server = this.serversByName[serverName]
         return {

--- a/src/methods/set.js
+++ b/src/methods/set.js
@@ -63,7 +63,6 @@ export function setProjectEnvironment () {
     this.setTypeEnvironment()
     this.setBackendEnvironment()
     this.setFrontendEnvironment()
-    this.setWelcomeEnvironment()
   }
 }
 

--- a/src/methods/write.js
+++ b/src/methods/write.js
@@ -24,6 +24,7 @@ export function writeProjectsByName (projectsByName) {
     try {
       fs.writeFileSync(fileDir, fileString)
     } catch (e) {
+      this.consoleWarn('Apparently you cannot write into your .projects.json located in your teleport folder app!')
       this.consoleWarn(e)
     }
   } else {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,4 @@
+export const templatePrefixes = [
+  '<REPLACE>',
+  '<REPLACE_FOR_EACH_TYPE>'
+]


### PR DESCRIPTION
…tion for deploy

@franblas 
here I polished some little things
- it is not anymore necessary to write `tpt -d --platform kubernetes` if there is only teleport-snips as platform
- replace prefixes are a bit smarter : __ if we want just to copy one time the file with the placeholders value, or _type_ if we want to copy them so many as there are different types