### PR TITLE
changed subDomain by infraName for the type docker server config

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
     "type": "git",
     "url": "https://github.com/snipsco/teleport"
   },
-  "version": "0.2.1"
+  "version": "0.2.2"
 }

--- a/src/methods/connect.js
+++ b/src/methods/connect.js
@@ -14,11 +14,11 @@ export function connect () {
 export function connectPorts () {
   this.checkProject()
   const { project: { config, dir } } = this
-  this.availablePortsBySubDomain = {}
+  this.availablePortsByInfraName = {}
   values(config.typesByName)
   .forEach(type => {
-    if (type.subDomain) {
-      this.availablePortsBySubDomain[type.subDomain] = this.getAvailablePorts(type.subDomain)
+    if (type.infraName) {
+      this.availablePortsByInfraName[type.infraName] = this.getAvailablePorts(type.infraName)
     }
   })
   if (config.backend && config.backend.serversByName) {
@@ -30,18 +30,18 @@ export function connectPorts () {
           if (typeof run === 'undefined') {
             run = server.runsByTypeName[typeName] = {}
           }
-          const subDomain = run.subDomain || config.typesByName[typeName].subDomain
-          if (typeof subDomain === 'undefined') {
+          const infraName = run.infraName || config.typesByName[typeName].infraName
+          if (typeof infraName === 'undefined') {
             return
           }
-          if (this.availablePortsBySubDomain[subDomain]) {
-            const availablePorts = this.availablePortsBySubDomain[subDomain]
+          if (this.availablePortsByInfraName[infraName]) {
+            const availablePorts = this.availablePortsByInfraName[infraName]
             if (availablePorts.length < 1) {
               this.consoleWarn('The required ports are unavailable. Free them up and retry.')
               process.exit()
             }
             run.port = availablePorts[0].toString()
-            this.availablePortsBySubDomain[subDomain] = availablePorts.slice(1)
+            this.availablePortsByInfraName[infraName] = availablePorts.slice(1)
           }
         })
       })

--- a/src/methods/replace.js
+++ b/src/methods/replace.js
@@ -124,7 +124,7 @@ export function replaceServerPlaceholderFiles () {
         }
         // no need also to replace and write when actually there is already the
         // locahost placeholder file
-        const localhostTemplateDir = `${templatePathDir}/__localhost_${installedFileName}`
+        const localhostTemplateDir = `${templatePathDir}/<REPLACE>localhost_${installedFileName}`
         if (fs.existsSync(localhostTemplateDir)) {
           return
         }

--- a/src/methods/set.js
+++ b/src/methods/set.js
@@ -249,7 +249,7 @@ export function setRunEnvironment () {
   // set the docker image
   if (run.name !== 'localhost') {
     if (backend.helpersByName && backend.helpersByName.kubernetes) {
-      run.nodeName = `${run.subDomain}.${backend.nodeDomain}`
+      run.nodeName = `${run.infraName}.${backend.helpersByName.kubernetes.nodeDomain}`
       // special case where we give to the host just the name of the dockerHost
       if (!type.hasDns) {
         run.host = run.nodeName


### PR DESCRIPTION
actually the connect method that helps to determine the avaiable ports in our kubernetes infra was not working anymore, because we had conflicting variables with subDomain name.

Now, with also the PR here https://github.com/snipsco/teleport-snips/pull/2
it should be okay